### PR TITLE
Fix: 修复bot不再响应其他中间件内容的问题

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -83,13 +83,14 @@ export function apply(ctx: Context, config: Config) {
             }
           });
         }
-        if (!content || content === " " || content === "") next();
+        if (!content || content === " " || content === "") return next();
         let cmd: string = await getResponse(content);
         if (cmd == config.symbol) {
-          return cmd;
+          return next();
         }
         session.execute(cmd);
-        next()
+      } else {
+        return next();
       }
     })
   };


### PR DESCRIPTION
#1 

修改了监听 @ 的中间件的逻辑：
接收到 @ 以外的消息时，直接进入下一个中间件。
接收到 @ 消息但没有匹配的指令时，也进入下一个中间件。
接收到 @ 消息且匹配到指令时，执行指令且不将消息传入下个中间件。